### PR TITLE
Avoid even suggesting /dev/sda as target

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Pass `OVMF=/path/to/OVMF_CODE.fd` to `make` if your OVMF BIOS file isn't in the 
 An x86_64-based system is required.
 
 By writing the PDF directly to a disk, you can boot it on a BIOS / UEFI system:
-  1. Run `dd if=/path/to/bootable.pdf of=/dev/sda bs=1M oflag=direct`
-      - **Be sure to replace `/dev/sda` with the path to your USB drive**
+  1. Run `dd if=/path/to/bootable.pdf of=/dev/SOMETHING bs=1M oflag=direct`
+      - **Be sure to replace `/dev/SOMETHING` with the path to your USB drive**
   2. Start your machine and boot from the drive (you will probably need to spam a key to get a boot menu)
 
 If you're on Windows, something like [Rufus](https://rufus.ie) in DD mode should work.


### PR DESCRIPTION
Given the potential catastrophic consequences of someone executing the suggested command (having not read or understood what follows), I think /dev/sda should be changed to placeholder text.